### PR TITLE
NIFI-12296 Added Apache Doris processor (StreamLoad based)

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -911,6 +911,18 @@ language governing permissions and limitations under the License. -->
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-api-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api-nar/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-doris-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-client-service-api-nar</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-processors</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-doris-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-client-service-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/src/main/java/org/apache/nifi/doris/DorisClientService.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/src/main/java/org/apache/nifi/doris/DorisClientService.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.doris;
+
+import org.apache.http.client.methods.HttpPut;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.doris.util.Result;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public interface DorisClientService extends ControllerService {
+
+    public HashMap<String, HttpPut> setClient(String destDatabase, String destTableName, String columns);
+
+    public void testConnectivity(ConfigurationContext context) throws IOException;
+
+    public void select();
+
+    public Result putJson(String jsonData, String database, String tableName);
+
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/src/main/java/org/apache/nifi/doris/util/Result.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-api/src/main/java/org/apache/nifi/doris/util/Result.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.doris.util;
+
+public class Result {
+    private String loadResult;
+    private int statusCode;
+
+    public String getLoadResult() {
+        return loadResult;
+    }
+
+    public void setLoadResult(String loadResult) {
+        this.loadResult = loadResult;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public String toString() {
+        return "Result{" +
+                "loadResult='" + loadResult + '\'' +
+                ", statusCode=" + statusCode +
+                '}';
+    }
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service-nar/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-doris-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-client-service-nar</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-api-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-doris-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-client-service</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-client-provider-api</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/main/java/org/apache/nifi/doris/DorisClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/main/java/org/apache/nifi/doris/DorisClientServiceImpl.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.doris;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.controller.ControllerServiceInitializationContext;
+import org.apache.nifi.doris.util.Result;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.InitializationException;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.HashMap;
+
+@RequiresInstanceClassLoading
+@Tags({"doris", "client", "stream_lode"})
+@CapabilityDescription("A controller service for accessing an Apache Doris client.")
+public class DorisClientServiceImpl extends AbstractControllerService implements DorisClientService {
+    private String feHost;
+    private String userName;
+    private String password;
+    private String httpPort;
+    private String loginLabel;
+
+    private String loadUrlFormat;
+    private String loginActionUrlFormat;
+    private String httpTimeOut;
+    private ConfigurationContext context;
+    private String columnSeparator;
+    private String dataFormat;
+    private String stripOuterArray;
+
+    public static final PropertyDescriptor FE_HOST = new PropertyDescriptor
+            .Builder().name("Fe Host")
+            .description("Apache Doris Frontend address")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor USERNAME = new PropertyDescriptor
+            .Builder().name("Username")
+            .description("Connect to the Apache Doris username.Note that this user needs to have read and write access to the corresponding table")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor PASSWORD = new PropertyDescriptor
+            .Builder().name("Password")
+            .description("Password to connect to Apache Doris")
+            .required(false)
+            .sensitive(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+
+    public static final PropertyDescriptor HTTP_PORT = new PropertyDescriptor
+            .Builder().name("Http Port")
+            .description("http server port on the FE")
+            .required(false)
+            .defaultValue("8030")
+            .addValidator(StandardValidators.PORT_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor LOAD_URL_FORMAT = new PropertyDescriptor
+            .Builder().name("Load URL")
+            .description("Stream Load URL. The placeholders are, in turn, feHost, httpPort, destDatabase, destTableName, as described in the Apache Doris documentation")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("http://%s:%s/api/%s/%s/_stream_load")
+            .build();
+
+    public static final PropertyDescriptor LOGIN_ACTION_URL_FORMAT = new PropertyDescriptor
+            .Builder().name("Login Action URL Format")
+            .description("For login services.This connection is invoked when the Service is in the onEnabled " +
+                    "state to test that the communication with the Doris server is normal")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("http://%s:%s/rest/v1/login")
+            .build();
+
+    public static final PropertyDescriptor LABEL = new PropertyDescriptor
+            .Builder().name("Label")
+            .description("Doris import jobs can all set a Label. This Label is usually a user-defined string that has certain business logic properties.\n" +
+                    "The main purpose of Label is to uniquely identify an import task and ensure that the same Label will only be successfully imported once.\n" +
+                    "The Label mechanism can ensure that the imported data is not lost and not heavy. If the upstream data source can guarantee the At-Least-Once semantics," +
+                    " then with the Label mechanism of Doris, the Exactly-Once semantics can be guaranteed.\n" +
+                    "Label is unique under a database. The default retention period for labels is 3 days. That is, after 3 days, the finished labels are automatically cleaned up, " +
+                    "after which the labels can be reused." +
+                    "Note that this label validates the user login and does nothing else")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("label-" + UUID.randomUUID())
+            .build();
+
+
+    public static final PropertyDescriptor DATA_FORMAT = new PropertyDescriptor
+            .Builder().name("Data Format")
+            .description("The underlying format of the data, which defaults to json data")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("json")
+            .build();
+
+    public static final PropertyDescriptor HTTP_TIME_OUT = new PropertyDescriptor
+            .Builder().name("Http Time Out")
+            .description("http connection timeout")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("10000")
+            .build();
+
+    public static final PropertyDescriptor COLUMN_SEPARATOR = new PropertyDescriptor
+            .Builder().name("Column Separator")
+            .description("Column separator")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue(",")
+            .build();
+
+    public static final PropertyDescriptor STRIP_OUTER_ARRAY = new PropertyDescriptor
+            .Builder().name("Strip Outer Array")
+            .description("As it parses, Doris expands the array and parses each Object as a row.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("true")
+            .build();
+    private List<PropertyDescriptor> properties;
+
+
+    @Override
+    protected void init(ControllerServiceInitializationContext config) throws InitializationException {
+        final List<PropertyDescriptor> props = new ArrayList<>();
+        props.add(FE_HOST);
+        props.add(USERNAME);
+        props.add(PASSWORD);
+        props.add(HTTP_PORT);
+        props.add(LABEL);
+        props.add(DATA_FORMAT);
+        props.add(LOAD_URL_FORMAT);
+        props.add(LOGIN_ACTION_URL_FORMAT);
+        props.add(HTTP_TIME_OUT);
+        props.add(COLUMN_SEPARATOR);
+        props.add(STRIP_OUTER_ARRAY);
+        this.properties = Collections.unmodifiableList(props);
+    }
+
+
+    HashMap<String, HttpPut> connect = new HashMap();
+    final CloseableHttpClient client = httpClientBuilder.build();
+    private final static HttpClientBuilder httpClientBuilder = HttpClients
+            .custom()
+            .setRedirectStrategy(new DefaultRedirectStrategy() {
+                @Override
+                protected boolean isRedirectable(String method) {
+                    // If the connection target is FE, you need to deal with 307 redirect。
+                    return true;
+                }
+            });
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    /**
+     * @param context the configuration context
+     * @throws InitializationException if unable to create a database connection
+     */
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) throws InitializationException, IOException {
+        this.context = context;
+        httpPort = context.getProperty(HTTP_PORT).evaluateAttributeExpressions().getValue();
+        loginLabel = context.getProperty(LABEL).evaluateAttributeExpressions().getValue();
+        feHost = context.getProperty(FE_HOST).evaluateAttributeExpressions().getValue();
+        userName = context.getProperty(USERNAME).evaluateAttributeExpressions().getValue();
+        password = context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue();
+        loadUrlFormat = context.getProperty(LOAD_URL_FORMAT).evaluateAttributeExpressions().getValue();
+        loginActionUrlFormat = context.getProperty(LOGIN_ACTION_URL_FORMAT).evaluateAttributeExpressions().getValue();
+        httpTimeOut = context.getProperty(HTTP_TIME_OUT).evaluateAttributeExpressions().getValue();
+        dataFormat = context.getProperty(DATA_FORMAT).evaluateAttributeExpressions().getValue();
+        columnSeparator = context.getProperty(COLUMN_SEPARATOR).evaluateAttributeExpressions().getValue();
+        stripOuterArray = context.getProperty(STRIP_OUTER_ARRAY).evaluateAttributeExpressions().getValue();
+        testConnectivity(context);
+    }
+
+    @OnDisabled
+    public void shutdown() {
+        if (null != client) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void testConnectivity(final ConfigurationContext context) throws IOException {
+
+        String loginUrl = String.format(loginActionUrlFormat, feHost, httpPort);
+        HttpPost httpPost = new HttpPost(loginUrl);
+        httpPost.removeHeaders(HttpHeaders.CONTENT_LENGTH);
+        httpPost.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
+        httpPost.setHeader(HttpHeaders.EXPECT, "100-continue");
+        httpPost.setHeader(HttpHeaders.TIMEOUT, httpTimeOut);
+        httpPost.setHeader(HttpHeaders.AUTHORIZATION, basicAuthHeader(userName, password));
+        httpPost.setHeader("label", loginLabel);
+
+        CloseableHttpResponse response = client.execute(httpPost);
+
+        if (response.getEntity() != null) {
+            String loadResult = EntityUtils.toString(response.getEntity());
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                throw new RuntimeException(String.format("Doris Stream load failed. status: %s load result: %s", statusCode, loadResult));
+            }
+        } else {
+            throw new RuntimeException("Doris Stream load failed.");
+        }
+    }
+
+    @Override
+    public HashMap<String, HttpPut> setClient(String destDatabase, String destTableName, String columns) {
+
+        if (null == connect.get(destDatabase + destTableName)) {
+            String loadUrl = String.format(loadUrlFormat, feHost, httpPort, destDatabase, destTableName);
+            HttpPut httpPut = new HttpPut(loadUrl);
+            httpPut.removeHeaders(HttpHeaders.CONTENT_LENGTH);
+            httpPut.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
+            httpPut.setHeader(HttpHeaders.TIMEOUT, httpTimeOut);
+            httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
+            httpPut.setHeader(HttpHeaders.AUTHORIZATION, basicAuthHeader(userName, password));
+
+            httpPut.setHeader("column_separator", columnSeparator);
+            httpPut.setHeader("format", dataFormat);
+            httpPut.setHeader("columns", columns);
+            httpPut.setHeader("strip_outer_array", stripOuterArray);
+            connect.put(destDatabase + destTableName, httpPut);
+        }
+        return connect;
+    }
+
+    private String basicAuthHeader(String username, String password) {
+        final String tobeEncode = username + ":" + password;
+        byte[] encoded = Base64.encodeBase64(tobeEncode.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + new String(encoded);
+    }
+
+
+    @Override
+    public void select() {
+
+    }
+
+
+    @Override
+    public Result putJson(String jsonData, String destDatabase, String destTableName) {
+        try {
+            HttpPut httpPut = connect.get(destDatabase + destTableName);
+            Result result = new Result();
+            if (null == httpPut) {
+                getLogger().error("Description Failed to initialize the doris connection.");
+                throw new RuntimeException();
+            }
+            httpPut.setEntity(new StringEntity(jsonData));
+            CloseableHttpResponse response = client.execute(httpPut);
+            if (response.getEntity() != null) {
+                String loadResult = EntityUtils.toString(response.getEntity());
+                result.setLoadResult(loadResult);
+                int statusCode = response.getStatusLine().getStatusCode();
+                result.setStatusCode(statusCode);
+            } else {
+                throw new RuntimeException("Doris Stream load failed.");
+            }
+            return result;
+
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        } catch (ClientProtocolException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.doris.DorisClientServiceImpl

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/test/java/org/apache/nifi/doris/TestDorisClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/test/java/org/apache/nifi/doris/TestDorisClientServiceImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.doris;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestDorisClientServiceImpl {
+
+    @BeforeEach
+    public void init() {
+
+    }
+
+    @Test
+    public void testService() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(TestProcessor.class);
+        final DorisClientServiceImpl service = new DorisClientServiceImpl();
+        runner.addControllerService("test-good", service);
+
+        runner.setProperty(service, DorisClientServiceImpl.FE_HOST, "test-value");
+        runner.enableControllerService(service);
+
+        runner.assertValid(service);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/test/java/org/apache/nifi/doris/TestProcessor.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-client-service/src/test/java/org/apache/nifi/doris/TestProcessor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.doris;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+
+public class TestProcessor extends AbstractProcessor {
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        List<PropertyDescriptor> propDescs = new ArrayList<>();
+        propDescs.add(new PropertyDescriptor.Builder()
+                .name("MyService test processor")
+                .description("MyService test processor")
+                .identifiesControllerService(DorisClientService.class)
+                .required(true)
+                .build());
+        return propDescs;
+    }
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-doris-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-properties</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-path</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-doris-client-service-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-services</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/java/org/apache/nifi/processors/doris/DorisFlowFile.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/java/org/apache/nifi/processors/doris/DorisFlowFile.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.doris;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.nifi.flowfile.FlowFile;
+
+import java.util.Objects;
+
+public class DorisFlowFile {
+    private String srcDatabaseName;
+    private String srcTableName;
+    private String columns;
+    private FlowFile flowFile;
+
+    private JsonNode jsonNode;
+
+    /*public DorisFlowFile(String srcDatabaseName, String srcTableName, String columns, FlowFile flowFile, JsonNode jsonData) {
+        this.srcDatabaseName = srcDatabaseName;
+        this.srcTableName = srcTableName;
+        this.columns = columns;
+        this.flowFile = flowFile;
+        this.jsonData = jsonData;
+    }*/
+
+    public String getSrcDatabaseName() {
+        return srcDatabaseName;
+    }
+
+    public String getSrcTableName() {
+        return srcTableName;
+    }
+
+    public String getColumns() {
+        return columns;
+    }
+
+    public FlowFile getFlowFile() {
+        return flowFile;
+    }
+
+    public JsonNode getJsonNode() {
+        return jsonNode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DorisFlowFile that = (DorisFlowFile) o;
+
+        if (!Objects.equals(srcDatabaseName, that.srcDatabaseName))
+            return false;
+        if (!Objects.equals(srcTableName, that.srcTableName)) return false;
+        if (!Objects.equals(columns, that.columns)) return false;
+        if (!Objects.equals(flowFile, that.flowFile)) return false;
+        return Objects.equals(jsonNode, that.jsonNode);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = srcDatabaseName != null ? srcDatabaseName.hashCode() : 0;
+        result = 31 * result + (srcTableName != null ? srcTableName.hashCode() : 0);
+        result = 31 * result + (columns != null ? columns.hashCode() : 0);
+        result = 31 * result + (flowFile != null ? flowFile.hashCode() : 0);
+        result = 31 * result + (jsonNode != null ? jsonNode.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DorisFlowFile{" +
+                "srcDatabaseName='" + srcDatabaseName + '\'' +
+                ", srcTableName='" + srcTableName + '\'' +
+                ", columns='" + columns + '\'' +
+                ", flowFile=" + flowFile +
+                ", jsonData=" + jsonNode +
+                '}';
+    }
+
+    public void setSrcDatabaseName(String srcDatabaseName) {
+        this.srcDatabaseName = srcDatabaseName;
+    }
+
+    public void setSrcTableName(String srcTableName) {
+        this.srcTableName = srcTableName;
+    }
+
+    public void setColumns(String columns) {
+        this.columns = columns;
+    }
+
+    public void setFlowFile(FlowFile flowFile) {
+        this.flowFile = flowFile;
+    }
+
+    public void setJsonNode(JsonNode jsonNode) {
+        this.jsonNode = jsonNode;
+    }
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/java/org/apache/nifi/processors/doris/PutDoris.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/java/org/apache/nifi/processors/doris/PutDoris.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.doris;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.doris.DorisClientService;
+import org.apache.nifi.doris.util.Result;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.HashSet;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+@Tags({"Doris","CDC","StreamLoad","Apache Doris"})
+@CapabilityDescription("StreamLoad the json data to Apache Doris")
+@SupportsBatching
+public class PutDoris extends AbstractProcessor {
+
+    private List<PropertyDescriptor> descriptors;
+    private Set<Relationship> relationships;
+    protected DorisClientService dorisClientService;
+    protected HashMap<String, String> oneToOneMap = new HashMap<>();
+    private volatile int batchSize;
+    private String srcDatabaseName;
+    private String srcTableName;
+    private String deleteSign;
+    private String op;
+    private int bufferSize;
+
+    final ObjectMapper mapper = new ObjectMapper();
+
+    public static final PropertyDescriptor DORIS_CLIENT_SERVICE = new PropertyDescriptor
+            .Builder().name("Doris Client Service")
+            .description("Used to create a Doris client, where the Doris client configuration needs to be configured")
+            .required(true)
+            .identifiesControllerService(DorisClientService.class)
+            .build();
+
+    public static final PropertyDescriptor SRC_DATABASE_NAME_KEY = new PropertyDescriptor
+            .Builder().name("Src Database Name Key")
+            .description("The key in json data, the default value is database, " +
+                    "if your data does not come from a relational database (perhaps a kafka stream or other)," +
+                    " you can customize this field. See the ONETOONE configuration explanation for details")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("database")
+            .build();
+
+    public static final PropertyDescriptor SRC_TABLE_NAME_KEY = new PropertyDescriptor
+            .Builder().name("Src Table Name Key")
+            .description("The key in json data, the default value is table_name, " +
+                    "if your data does not come from a relational database (perhaps a kafka stream or other)," +
+                    " you can customize this field. See the ONETOONE configuration explanation for details")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("table_name")
+            .build();
+
+    public static final PropertyDescriptor DELETE_SIGN = new PropertyDescriptor
+            .Builder().name("Delete Sign")
+            .description("__DORIS_DELETE_SIGN__ is a hidden column in doris that indicates whether the data of the row should be deleted or not," +
+                    "in cdc, __DORIS_DELETE_SIGN__ is true to indicate that the row should be deleted or false to indicate insertion. " +
+                    "See the Apache Doris documentation for more details")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("__DORIS_DELETE_SIGN__")
+            .build();
+
+    public static final PropertyDescriptor OP = new PropertyDescriptor
+            .Builder().name("Op Key")
+            .description("The key in json data, the default value is op. If you want to replace it with another field, you can change this value:\n" +
+                    "The PutDoris processor reads the value of op in the data and uses it to determine __DORIS_DELETE_SIGN__; " +
+                    "if op is delete, __DORIS_DELETE_SIGN__=true; otherwise, __DORIS_DELETE_SIGN__ is false")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("op")
+            .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Files that have been successfully written to Apache Doirs are transferred to this relationship")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("Files that could not be written to Apache Doirs for some reason are transferred to this relationship")
+            .build();
+
+    public static final PropertyDescriptor ONETOONE = new PropertyDescriptor
+            .Builder().name("One To One")
+            .description("one-to-one means where did the data come from and be written to Apache Doris in which " +
+                    "database and which form (sample srcDatabase. SrcTable: destDatabase destTable, srcDatabase. SrcTable1: destDatabase. DestTable1, foo...):\n" +
+                    "eg:\n" +
+                    "(Assume SRC_DATABASE_NAME_KEY=database and SRC_TABLE_NAME_KEY=table_name)\n" +
+                    "There are three json pieces of data in the queue\n" +
+                    "data1 -&gt;  {\"database\":\"db1\",\"table_name\":\"tab1\",\"field1\":\"a\",\"field2\":\"b\"}\n" +
+                    "data2 -&gt;  {\"database\":\"db1\",\"table_name\":\"tab2\",\"field1\":\"a\",\"field2\":\"b\"}\n" +
+                    "data3 -&gt;  {\"database\":\"db2\",\"table_name\":\"tab1\",\"field1\":\"a\",\"field2\":\"b\"}\n" +
+                    "\n" +
+                    "1. If not configured, SRC_DATABASE_NAME_KEY and SRC_TABLE_NAME_KEY will be used as the database and table to be written to\n" +
+                    "Result: data1 will be written to doris with database db1 and table tab1\n" +
+                    "        data2 is written to doris, whose database is db1 and whose table is tab2\n" +
+                    "        data3 is written to doris with db2 as database and tab1 as table\n" +
+                    "If configured, db1.tab1:db1_doris.tab_doris1,db1.tab2:db1_doris.tab_doris1,db2.tab1:db1_doris.tab_doris1\n" +
+                    "Result: data1 is written to doris with db1_doris as database and tab_doris1 as table\n" +
+                    "        data2 is written to doris with db1_doris as the database and tab_doris1 as the table\n" +
+                    "        data3 is written to doris with db1_doris as the database and tab_doris1 as the table\n" +
+                    "Note: If you configure ONETOONE, you need to configure all the data relationships to be synchronized in ONETOONE to prevent data confusion")
+            .required(false)
+            .addValidator(StandardValidators.createRegexMatchingValidator(Pattern.compile("(\\w+\\.\\w+:\\w+\\.\\w+)(,\\w+\\.\\w+:\\w+\\.\\w+)*")))
+            .build();
+
+    public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("Batch Size")
+            .description("The maximum number of FlowFiles to process in a single execution, between 1 - 100000. " +
+                    "Depending on your memory size, and data size per row set an appropriate batch size " +
+                    "for the number of FlowFiles to process per client connection setup." +
+                    "Gradually increase this number, only if your FlowFiles typically contain a few records.")
+            .defaultValue("1")
+            .required(false)
+            .addValidator(StandardValidators.createLongValidator(1, 100000, true))
+            .build();
+
+    public static final PropertyDescriptor BUFFER_SIZE = new PropertyDescriptor.Builder()
+            .name("Buffer Size")
+            .description("Character stream buffer size, 8k (8192) by default, can be increased for performance, which means it may take up more memory")
+            .defaultValue("8192")
+            .required(false)
+            .addValidator(StandardValidators.NUMBER_VALIDATOR)
+            .build();
+
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        descriptors = new ArrayList<>();
+        descriptors.add(DORIS_CLIENT_SERVICE);
+        descriptors.add(ONETOONE);
+        descriptors.add(BATCH_SIZE);
+        descriptors.add(SRC_DATABASE_NAME_KEY);
+        descriptors.add(SRC_TABLE_NAME_KEY);
+        descriptors.add(DELETE_SIGN);
+        descriptors.add(OP);
+        descriptors.add(BUFFER_SIZE);
+        descriptors = Collections.unmodifiableList(descriptors);
+
+        relationships = new HashSet<>();
+        relationships.add(REL_SUCCESS);
+        relationships.add(REL_FAILURE);
+        relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        dorisClientService = context.getProperty(DORIS_CLIENT_SERVICE).asControllerService(DorisClientService.class);
+        batchSize = context.getProperty(BATCH_SIZE).evaluateAttributeExpressions().asInteger();
+        srcDatabaseName = context.getProperty(SRC_DATABASE_NAME_KEY).evaluateAttributeExpressions().getValue();
+        srcTableName = context.getProperty(SRC_TABLE_NAME_KEY).evaluateAttributeExpressions().getValue();
+        deleteSign = context.getProperty(DELETE_SIGN).evaluateAttributeExpressions().getValue();
+        op = context.getProperty(OP).evaluateAttributeExpressions().getValue();
+        bufferSize = context.getProperty(BUFFER_SIZE).asInteger();
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        List<FlowFile> flowFiles = session.get(batchSize);
+        if (flowFiles.isEmpty()) {
+            return;
+        }
+
+        final Map<String, List<DorisFlowFile>> dorisFlowFiles = new HashMap<>();
+        for (final FlowFile flowFile : flowFiles) {
+            final AtomicReference<List<JsonNode>> rootNodeRef = new AtomicReference<>(null);
+
+            session.read(flowFile, in -> {
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in),bufferSize);
+                String line;
+                ArrayList<JsonNode> jnList = new ArrayList<>();
+                try {
+                    while ((line = bufferedReader.readLine()) != null) {
+                        JsonNode newNode = mapper.readTree(line);
+                        ObjectNode objectNode = (ObjectNode) newNode;
+
+                        if (null != objectNode.get(op) && "delete".equalsIgnoreCase(objectNode.get(op).asText())) {
+                            objectNode.put(deleteSign, true);
+                            jnList.add(objectNode);
+                        } else {
+                            objectNode.put(deleteSign, false);
+                            jnList.add(objectNode);
+                        }
+                        rootNodeRef.set(jnList);
+                    }
+
+                } catch (final ProcessException pe) {
+                    getLogger().error("failed to process session due to {}", new Object[]{flowFile, pe});
+                    session.transfer(flowFile, REL_FAILURE);
+                } finally {
+                    bufferedReader.close();
+                }
+            });
+
+            for (JsonNode jsonNode : rootNodeRef.get()) {
+                Iterator<String> fieldNames = jsonNode.fieldNames();
+                StringBuffer fieldNamesList = new StringBuffer();
+
+                while (fieldNames.hasNext()) {
+                    String fieldName = fieldNames.next();
+                    if (srcDatabaseName.equalsIgnoreCase(fieldName) || srcTableName.equalsIgnoreCase(fieldName) || deleteSign.equalsIgnoreCase(fieldName) || op.equalsIgnoreCase(fieldName)) {
+                        continue;
+                    }
+                    fieldNamesList.append("`" + fieldName + "`" + ",");
+                }
+                DorisFlowFile dorisFlowFile = new DorisFlowFile();
+                //del database and table_name
+                if (jsonNode.isObject()) {
+                    ObjectNode objectNode = (ObjectNode) jsonNode;
+
+                    dorisFlowFile.setSrcDatabaseName(jsonNode.get(srcDatabaseName).asText());
+                    dorisFlowFile.setSrcTableName(jsonNode.get(srcTableName).asText());
+                    dorisFlowFile.setColumns(fieldNamesList.toString().concat(deleteSign));
+                    dorisFlowFile.setFlowFile(flowFile);
+
+                    objectNode.remove(srcDatabaseName);
+                    objectNode.remove(srcTableName);
+                    objectNode.remove(op);
+                    dorisFlowFile.setJsonNode(jsonNode);
+                } else {
+                    dorisFlowFile = null;
+                }
+
+                if (dorisFlowFile == null) {
+                    getLogger().error("dorisFlowFile is null {}", new Object[]{dorisFlowFile});
+                    session.transfer(flowFile, REL_FAILURE);
+                }
+
+                List<DorisFlowFile> dff = dorisFlowFiles.get(dorisFlowFile.getSrcDatabaseName().concat(".").concat(dorisFlowFile.getSrcTableName()));
+
+                if (dff == null) {
+                    dff = new ArrayList<>();
+                    dorisFlowFiles.put(dorisFlowFile.getSrcDatabaseName().concat(".").concat(dorisFlowFile.getSrcTableName()), dff);
+                }
+                dff.add(dorisFlowFile);
+
+            }
+
+        }
+
+        if (context.getProperty(ONETOONE).isSet()) {
+            //srcDatabase.srcTable:destDatabase.destTable,srcDatabase.srcTable1:destDatabase.destTable1,foo...
+            String oneToOneValue = context.getProperty(ONETOONE).evaluateAttributeExpressions().getValue();
+            String[] split = oneToOneValue.split(",", -1);
+            for (String s : split) {
+                String[] databaseAndTable = s.split(":", -1);
+                oneToOneMap.put(databaseAndTable[0], databaseAndTable[1]);
+            }
+        }
+
+        //key -> destDbNameAndDestTabName , value -> List<>(jsonData)
+        HashMap<String, List<String>> putJsonMap = new HashMap<>();
+
+        for (Map.Entry<String, List<DorisFlowFile>> stringListEntry : dorisFlowFiles.entrySet()) {
+
+            String srcDbAndTab = stringListEntry.getKey();
+            String destDbAndTab = oneToOneMap.getOrDefault(srcDbAndTab, srcDbAndTab);
+
+            List<DorisFlowFile> value = stringListEntry.getValue();
+
+            for (DorisFlowFile dorisFlowFile : value) {
+                //init client
+                String destDatabase = destDbAndTab.split("\\.", -1)[0];
+                String destTableName = destDbAndTab.split("\\.", -1)[1];
+                dorisClientService.setClient(destDatabase, destTableName, dorisFlowFile.getColumns());
+
+                //Build the putJsonMap
+                List<String> jsonList = putJsonMap.get(destDbAndTab);
+                if (null == jsonList) {
+                    jsonList = new ArrayList<>();
+                    putJsonMap.put(destDbAndTab, jsonList);
+                }
+                jsonList.add(dorisFlowFile.getJsonNode().toString());
+
+            }
+
+        }
+        //Delete the original flowfile
+        session.remove(flowFiles);
+
+        //Write the data to doris
+        for (Map.Entry<String, List<String>> stringListEntry : putJsonMap.entrySet()) {
+
+            String key = stringListEntry.getKey();
+            String destDatabase = key.split("\\.", -1)[0];
+            String destTableName = key.split("\\.", -1)[1];
+            List<String> value = putJsonMap.get(key);
+            String join = String.join("\n", value);
+            FlowFile putFlowFile = session.create();
+            session.write(putFlowFile, outputStream -> outputStream.write(join.getBytes()));
+
+            try {
+                Result result = dorisClientService.putJson(stringListEntry.getValue().toString(), destDatabase, destTableName);
+                getLogger().info(result.getLoadResult().toString());
+                if (result.getStatusCode() != 200) {
+                    throw new RuntimeException(String.format("Doris Stream load failed. status: %s load result: %s", result.getStatusCode(), result.getLoadResult()));
+                }
+                if (!"Success".equalsIgnoreCase(mapper.readTree(result.getLoadResult()).get("Status").asText())) {
+                    throw new RuntimeException(String.format("Doris Stream load failed. status: %s load Message: %s",
+                            result.getStatusCode(), mapper.readTree(result.getLoadResult()).get("Message").asText()));
+                }
+
+                session.transfer(putFlowFile, REL_SUCCESS);
+            } catch (Exception e) {
+                getLogger().error(e.toString());
+                session.transfer(putFlowFile, REL_FAILURE);
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.doris.PutDoris

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/test/java/org/apache/nifi/processors/doris/MockDorisClientServiceTest.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/test/java/org/apache/nifi/processors/doris/MockDorisClientServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.doris;
+
+import org.apache.http.client.methods.HttpPut;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.doris.DorisClientService;
+import org.apache.nifi.doris.util.Result;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class MockDorisClientServiceTest extends AbstractControllerService implements DorisClientService {
+
+    @Override
+    public HashMap<String, HttpPut> setClient(String destDatabase, String destTableName, String columns) {
+        return null;
+    }
+
+    @Override
+    public void testConnectivity(ConfigurationContext context) throws IOException {
+
+    }
+
+    @Override
+    public void select() {
+
+    }
+
+    @Override
+    public Result putJson(String jsonData, String database, String tableName) {
+        return null;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/test/java/org/apache/nifi/processors/doris/TestPutDoris.java
+++ b/nifi-nar-bundles/nifi-doris-bundle/nifi-doris-processors/src/test/java/org/apache/nifi/processors/doris/TestPutDoris.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.doris;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestPutDoris {
+
+    /*@Test
+    public void testMainProcesses() throws InitializationException {
+        TestRunner runner = getTestRunner();
+        runner.setProperty(PutDoris.BATCH_SIZE, "2");
+        getDorisClientServiceTest(runner);
+        String data = "{\"a\": \"111s\", \"b\": 1, \"c\": \"1s\", \"d\": null, \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"55\", \"b\": 55, \"c\": \"ddddsss\", \"d\": null, \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"a01\", \"b\": 1103, \"c\": \"c01\", \"d\": \"d01\", \"database\": \"cdc1\", \"table_name\": \"test2\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"a1\", \"b\": 1002, \"c\": \"a1\", \"d\": \"a1\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"a2\", \"b\": 1003, \"c\": \"a1\", \"d\": \"a1\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"aa\", \"b\": 101, \"c\": \"cc\", \"d\": \"dd\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"update\"}\n" +
+                "{\"a\": \"ddd\", \"b\": 35, \"c\": \"w\", \"d\": \"d\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}\n" +
+                "{\"a\": \"ssd\", \"b\": 23, \"c\": \"sd\", \"d\": \"x\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"delete\"}\n" +
+                "{\"a\": \"ssds\", \"b\": 231, \"c\": \"dd\", \"d\": \"ssss\", \"database\": \"cdc1\", \"table_name\": \"test1\",\"op\":\"insert\"}";
+        MockFlowFile mockFlowFile = new MockFlowFile(1);
+        MockFlowFile mockFlowFile2 = new MockFlowFile(2);
+        mockFlowFile2.setData(data.getBytes());
+        mockFlowFile.setData(data.getBytes());
+
+        Map<String, String> attributes = new HashMap<>();
+        mockFlowFile.putAttributes(attributes);
+
+        runner.enqueue(mockFlowFile,mockFlowFile2);
+        runner.run();
+        runner.assertValid();
+    }*/
+
+
+
+    private TestRunner getTestRunner() {
+        TestRunner testRunner = TestRunners.newTestRunner(PutDoris.class);
+        return testRunner;
+    }
+
+    private void getDorisClientServiceTest(TestRunner testRunner) throws InitializationException {
+        MockDorisClientServiceTest mockDorisClientServiceTest = new MockDorisClientServiceTest();
+        testRunner.addControllerService("dorisClient", mockDorisClientServiceTest);
+        testRunner.enableControllerService(mockDorisClientServiceTest);
+        testRunner.setProperty(PutDoris.DORIS_CLIENT_SERVICE, "dorisClient");
+    }
+}

--- a/nifi-nar-bundles/nifi-doris-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-doris-bundle/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-doris-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-doris-client-service-api</module>
+        <module>nifi-doris-client-service-api-nar</module>
+        <module>nifi-doris-client-service</module>
+        <module>nifi-doris-processors</module>
+        <module>nifi-doris-client-service-nar</module>
+    </modules>
+
+</project>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -116,6 +116,7 @@
         <module>nifi-compress-bundle</module>
         <module>nifi-opentelemetry-bundle</module>
         <module>nifi-apicurio-bundle</module>
+        <module>nifi-doris-bundle</module>
     </modules>
 
     <build>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
